### PR TITLE
fix(import): Changing the way we import Carbon Components

### DIFF
--- a/components/DetailPageHighlights/DetailPageHighlights.js
+++ b/components/DetailPageHighlights/DetailPageHighlights.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import MarkdownRenderer from '../../internal/MarkdownRenderer/MarkdownRenderer';
-import { Notification } from 'carbon-components-react';
+import { Notification } from '../../index';
 
 const propTypes = {
   artifact: PropTypes.object,

--- a/components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js
+++ b/components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Notification } from 'carbon-components-react';
+import { Notification } from '../../index';
 
 const propTypes = {
   artifact: PropTypes.object,

--- a/components/DetailPageSidebar/DetailPageSidebar.js
+++ b/components/DetailPageSidebar/DetailPageSidebar.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { Tag } from 'carbon-components-react';
+import { Tag } from '../../index';
 
 class DetailPageSidebar extends Component {
   static propTypes = {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+import Notification from './node_modules/carbon-components-react/cjs/components/Notification';
+import Tag from './node_modules/carbon-components-react/cjs/components/Tag';
+
+export {
+  Notification,
+  Tag,
+};
+
 export DetailPageSidebar from './components/DetailPageSidebar/DetailPageSidebar.js';
 export DetailPageHighlights from './components/DetailPageHighlights/DetailPageHighlights.js';
 export DetailPageHighlightsSimple from './components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js';


### PR DESCRIPTION
This PR enables us to pull components from the carbon-components-react
files directly. We are hoping that this fix will prevent users from
pulling in about 300kb of extra data that they don't necessarily want.