### PR TITLE
fix(splitimports): Separating carbon-react vs. addon imports

### DIFF
--- a/components/DetailPageHighlights/DetailPageHighlights.js
+++ b/components/DetailPageHighlights/DetailPageHighlights.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import MarkdownRenderer from '../../internal/MarkdownRenderer/MarkdownRenderer';
-import { Notification } from '../../index';
+import { Notification } from '../carbon';
 
 const propTypes = {
   artifact: PropTypes.object,

--- a/components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js
+++ b/components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Notification } from '../../index';
+import { Notification } from '../carbon';
 
 const propTypes = {
   artifact: PropTypes.object,

--- a/components/DetailPageSidebar/DetailPageSidebar.js
+++ b/components/DetailPageSidebar/DetailPageSidebar.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { Tag } from '../../index';
+import { Tag } from '../carbon';
 
 class DetailPageSidebar extends Component {
   static propTypes = {

--- a/components/carbon.js
+++ b/components/carbon.js
@@ -1,0 +1,4 @@
+import Notification from '../node_modules/carbon-components-react/cjs/components/Notification';
+import Tag from '../node_modules/carbon-components-react/cjs/components/Tag';
+
+export { Notification, Tag };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-import Notification from 'carbon-components-react/cjs/components/Notification';
-import Tag from 'carbon-components-react/cjs/components/Tag';
-
-export {
-  Notification,
-  Tag,
-};
-
 export DetailPageSidebar from './components/DetailPageSidebar/DetailPageSidebar.js';
 export DetailPageHighlights from './components/DetailPageHighlights/DetailPageHighlights.js';
 export DetailPageHighlightsSimple from './components/DetailPageHighlightsSimple/DetailPageHighlightsSimple.js';


### PR DESCRIPTION
With the previous PR, we were importing all the addon components rather than only importing the ones the user wants. With this fix, hopefully we can only import select carbon-react components and addon components